### PR TITLE
Remove microprofile for 7.0.7 and update git commit

### DIFF
--- a/library/tomee
+++ b/library/tomee
@@ -1,6 +1,6 @@
 Maintainers: Alex Soto <asotobu@gmail.com> (@lordofthejars), Otavio Santana <otaviojava@apache.org> (@otaviojava), Jonathan Gallimore <jgallimore@apache.org> (@jgallimore), Rod Jenkins <jenkir14@nationwide.com> (@scriptmonkey)
 GitRepo: https://github.com/tomitribe/docker-tomee.git
-GitCommit: 042b7dbd684f9b3649b6d1b4b924f38dedf85c19
+GitCommit: c7642e963c08920560906159e126ea22b9ada61d
 Architectures: amd64
 
 Tags: 8-jre-7.0.7-plume, 7.0.7-plume
@@ -11,9 +11,6 @@ Directory: TomEE-7.0/jre8/plus
 
 Tags: 8-jre-7.0.7-webprofile, 7.0
 Directory: TomEE-7.0/jre8/webprofile
-
-Tags: 8-jre-7.0.7-microprofile, 7.0.7-microprofile
-Directory: TomEE-7.0/jre8/microprofile
 
 Tags: 8-jre-7.1.2-plume, 7.1.2-plume
 Directory: TomEE-7.1/jre8/plume


### PR DESCRIPTION
If you merge this into your branch, hopefully the official images will be able to merge the changes in and the images can be released.

Specifically, this removes the 7.0.x MicroProfile and updates the Git commit reference to docker/tomee.